### PR TITLE
Temporary fix to raffle.vue until date helpers are removed for dayjs

### DIFF
--- a/app/pages/admin/raffle.vue
+++ b/app/pages/admin/raffle.vue
@@ -34,7 +34,7 @@ onMounted(() => {
     <div class="week-row">
       <div>
         <p class="field-hint">Selected Week</p>
-        <h4 class="week-label">{{ raffleWeekStart ? 'Week of ' + getLastMonday(raffleWeekStart) : 'Select a week' }}</h4>
+        <h4 class="week-label">{{ raffleWeekStart ? 'Week of ' + getLastMonday(raffleWeekStart.toLocaleString()) : 'Select a week' }}</h4>
       </div>
       <div>
         <label class="field-label">Change Week Starting (Mon)</label>


### PR DESCRIPTION
deprecated getLastMonday and helper function parselocaldate require string input, where raffleWeekStart is a date object. Compatibility change was lost with earlier merge. Will need to switch to appropriate dayjs functions once implemented